### PR TITLE
BUG: fixes in norm and axes handling

### DIFF
--- a/cupy/fft/fft.py
+++ b/cupy/fft/fft.py
@@ -373,13 +373,17 @@ def _fftn(a, s, axes, norm, direction, value_type='C2C', order='A', plan=None,
                          % norm)
 
     a = _convert_dtype(a, value_type)
+
+    if (s is not None) and (axes is not None) and len(s) != len(axes):
+        raise ValueError('Shape and axes have different lengths.')
+
     if axes is None:
-        dim = a.ndim
+        if s is None:
+            dim = a.ndim
+        else:
+            dim = len(s)
         axes = [i for i in six.moves.range(-dim, 0)]
     axes = tuple(axes)
-
-    if (s is not None) and len(s) != len(axes):
-        raise ValueError('Shape and axes have different lengths.')
 
     if order == 'A':
         if a.flags.f_contiguous:

--- a/cupyx/scipy/fft/fft.py
+++ b/cupyx/scipy/fft/fft.py
@@ -232,7 +232,7 @@ def rfft(x, n=None, axis=-1, norm=None, overwrite_x=False):
 
 
 @_implements(_scipy_fft.irfft)
-def irfft(x, n=None, axis=-1, overwrite_x=False):
+def irfft(x, n=None, axis=-1, norm=None, overwrite_x=False):
     """Compute the one-dimensional inverse FFT for real input.
 
     Args:


### PR DESCRIPTION
Hi Peter,

With these two small fixes the tests pass locally for me aside from when using NumPy 1.17 which has different error types due to cupy/cupy#2361(numpy `ZeroDivisionError` issue).

The second commit here makes `_fftn` behavior consistent with NumPy (I verified for both 1.16.4 and 1.17.0). However, this does make the behavior inconsistent with `scipy.fft`. I opened scipy/scipy#10588 to suggest changing `scipy.fft`'s behavior to match NumPy.

Note: The shape/axis handling as proposed here was already being done this way in the 1D `cupy.fft._fft` function, the problem was only in `_fftn`.